### PR TITLE
Fix loading on thingworx and drop deprecated usages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2604,7 +2604,8 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
         "normalize-path": {
@@ -2868,7 +2869,8 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
         "normalize-path": {
@@ -8532,8 +8534,9 @@
       "dev": true
     },
     "typescriptwebpacksupport": {
-      "version": "github:stefan-lacatus/ThingworxWidgetSupportPackage#2f953675263c17ff3e7315311c2ab30d198e32b5",
-      "from": "github:stefan-lacatus/ThingworxWidgetSupportPackage#master"
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/typescriptwebpacksupport/-/typescriptwebpacksupport-2.0.9.tgz",
+      "integrity": "sha512-jdX4gMlL11wQEGVrhGplwMfj9PsvjvbFmxHqbDR5zIRPtx7bVVfIjekBQJSHwKYMZuYQXZPKhKmEeuX9Xd1TwQ=="
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",
@@ -9106,7 +9109,8 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
         "nanomatch": {
@@ -9328,7 +9332,8 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
         "tapable": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,6 @@
         "terser-webpack-plugin": "2.3.4"
     },
     "dependencies": {
-        "typescriptwebpacksupport": "github:stefan-lacatus/ThingworxWidgetSupportPackage#master"
+        "typescriptwebpacksupport": "^2.0.9"
     }
 }

--- a/src/BMView.ide.ts
+++ b/src/BMView.ide.ts
@@ -2,7 +2,7 @@
 ///<reference path="../../BMCoreUI/build/ui/BMCoreUI/BMCoreUI.d.ts"/>
 
 // automatically import the css file
-import { ThingworxComposerWidget } from 'typescriptwebpacksupport/widgetidesupport'
+import { TWWidgetDefinition } from 'typescriptwebpacksupport/widgetIDESupport'
 
 export class BMThingworxLayoutEditor extends BMViewLayoutEditor {
     bindableConstraints: Set<string> = new Set;
@@ -458,7 +458,7 @@ TW.IDE.Dialogs.BMViewWidget = function () {
  * The scroll view widget is a subclass of the view widget that allows the creation of
  * constraint based scrolling containers.
  */
-@ThingworxComposerWidget
+@TWWidgetDefinition('View')
 export class BMViewWidget extends TWComposerWidget implements BMLayoutEditorDelegate {
 
     /**
@@ -1160,7 +1160,7 @@ export class BMViewWidget extends TWComposerWidget implements BMLayoutEditorDele
  * The layout guide widget is a subclass of the view widget that allows the creation of
  * views whose position can be changed by users at runtime via drag & drop.
  */
-@ThingworxComposerWidget
+@TWWidgetDefinition('Scroll View')
 export class BMScrollViewWidget extends BMViewWidget {
 
     isTransparentToCoreUILayout: boolean = YES;
@@ -1254,7 +1254,7 @@ export class BMScrollViewWidget extends BMViewWidget {
  * The attributed label view widget is a subclass of the view widget that allows the creation of labels
  * that contain customizable arguments that can be bound independently.
  */
-@ThingworxComposerWidget
+@TWWidgetDefinition('Layout Guide')
 export class BMLayoutGuideWidget extends BMViewWidget {
 
     widgetIconUrl(): string {
@@ -1288,7 +1288,7 @@ export class BMLayoutGuideWidget extends BMViewWidget {
  * The attributed label view widget is a subclass of the view widget that allows the creation of labels
  * that contain customizable arguments that can be bound independently.
  */
-@ThingworxComposerWidget
+@TWWidgetDefinition('Label View')
 export class BMAttributedLabelViewWidget extends BMViewWidget {
 
 
@@ -1780,7 +1780,7 @@ export class BMAttributedLabelViewWidget extends BMViewWidget {
  * The text field widget is a subclass of the view widget that allows the creation of text fields that support
  * automatic completion and suggestions.
  */
-@ThingworxComposerWidget
+@TWWidgetDefinition('Text Field')
 export class BMTextFieldWidget extends BMViewWidget {
 
     renderHtml(): string {

--- a/src/BMView.ide.ts
+++ b/src/BMView.ide.ts
@@ -509,7 +509,7 @@ export class BMViewWidget extends TWComposerWidget implements BMLayoutEditorDele
     layoutVariableProvider: BMThingworxLayoutVariableProvider;
 
     widgetIconUrl(): string {
-        return require('./images/icon.png');
+        return require('./images/icon.png').default;
     }
 
     widgetProperties(): TWWidgetProperties {
@@ -1178,7 +1178,7 @@ export class BMScrollViewWidget extends BMViewWidget {
     _coreUIView: BMScrollView;
 
     widgetIconUrl(): string {
-        return require('./images/scrollViewIcon.png');
+        return require('./images/scrollViewIcon.png').default;
     }
 
     widgetProperties(): TWWidgetProperties {
@@ -1258,7 +1258,7 @@ export class BMScrollViewWidget extends BMViewWidget {
 export class BMLayoutGuideWidget extends BMViewWidget {
 
     widgetIconUrl(): string {
-        return require('./images/layoutGuideIcon.png');
+        return require('./images/layoutGuideIcon.png').default;
     }
 
     widgetProperties(): TWWidgetProperties {
@@ -1345,7 +1345,7 @@ export class BMAttributedLabelViewWidget extends BMViewWidget {
     }
 
     widgetIconUrl(): string {
-        return require('./images/labelViewIcon.png');
+        return require('./images/labelViewIcon.png').default;
     }
 
     widgetProperties(): TWWidgetProperties {

--- a/src/BMView.runtime.ts
+++ b/src/BMView.runtime.ts
@@ -1,4 +1,4 @@
-import { ThingworxRuntimeWidget, TWService, TWProperty } from 'typescriptwebpacksupport/widgetruntimesupport'
+import { TWWidgetDefinition, TWService, TWProperty } from 'typescriptwebpacksupport/widgetRuntimeSupport'
 
 //declare var BMLayoutConstraint: any;
 
@@ -172,7 +172,7 @@ export function BMViewForThingworxWidget(widget: TWRuntimeWidget): BMView {
  * The view widget allows the use of BMView and constraints based layouts in thingworx.
  * It also provides an editor that can be used to customize the layout.
  */
-@ThingworxRuntimeWidget
+@TWWidgetDefinition
 export class BMViewWidget extends TWRuntimeWidget {
 
     /**
@@ -597,7 +597,7 @@ export class BMViewWidget extends TWRuntimeWidget {
  * The scroll view widget is a subclass of the view widget that allows the creation of
  * constraint based scrolling containers.
  */
-@ThingworxRuntimeWidget
+@TWWidgetDefinition
 export class BMScrollViewWidget extends BMViewWidget {
 
     styleRule: DOMNode;
@@ -694,7 +694,7 @@ export class BMScrollViewWidget extends BMViewWidget {
  * The layout guide widget is a subclass of the view widget that allows the creation of
  * views whose position can be changed by users at runtime via drag & drop.
  */
-@ThingworxRuntimeWidget
+@TWWidgetDefinition
 export class BMLayoutGuideWidget extends BMViewWidget {
 
     @TWProperty('InitialPositionLeft')
@@ -757,7 +757,7 @@ function BMStringWithLocation(location: {latitude: any, longitude: any}, {usingF
  * The attributed label view widget is a subclass of the view widget that allows the creation of labels
  * that contain customizable arguments that can be bound independently.
  */
-@ThingworxRuntimeWidget
+@TWWidgetDefinition
 export class BMAttributedLabelViewWidget extends BMViewWidget {
     
     /**
@@ -1079,7 +1079,7 @@ export class BMAttributedLabelViewWidget extends BMViewWidget {
  * The text field widget is a subclass of the view widget that allows the creation of text fields that support
  * automatic completion and suggestions.
  */
-@ThingworxRuntimeWidget
+@TWWidgetDefinition
 export class BMTextFieldWidget extends BMViewWidget implements BMTextFieldDelegate {
 
     /**


### PR DESCRIPTION
## Intent

* Importing BMCoreWidgets (https://github.com/ptc-iot-sharing/BMCoreUIWidgets/releases/tag/2.6.6) breaks Mashup builder (tested on twx 9.1)
* Tracked the problem down to this repo

## Implementation

* Require the latest `typescriptwebpacksupport`
* Adopt the latest `TWWidgetDefinition`
* Make  `widgetIconUrl` always returns the full base64 data