### PR TITLE
Scrollview fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# 2.9.3
+
+Resolves an issue where the layout editor did not appear when invoked from a scroll view.
+
+Resolves an issue where constraints did not properly save when specified on a scroll content view.
+
+Resolves an issue where the scroll content view was not selectable in the layout editor.
+
+Resolves an issue where the constraints for a scroll content view were not properly created at runtime.
+
+Resolves an issue where the thingworx binding dropdown was not properly hidden when opening the layout editor.
+
 # 2.8.3
 
 Fixes a crash that would occur when closing the layout editor after removing a constraint that was marked bindable.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "BMView",
-    "version": "2.8.3",
+    "version": "2.9.3",
     "description": "Allows using BMView, BMLayoutEditor and constraint-based layouts in Thingworx.",
     "thingworxServer": "http://localhost:8016",
     "thingworxUser": "Administrator",

--- a/src/BMView.ide.ts
+++ b/src/BMView.ide.ts
@@ -995,7 +995,7 @@ export class BMViewWidget extends TWComposerWidget implements BMLayoutEditorDele
                 ID = ID.substring(0, ID.length - '-content-view'.length);
             }
 
-            let nodes = this.jqElement[0].querySelectorAll('#' + ID);
+            let nodes = this.jqElement[0].parentElement.querySelectorAll('#' + ID);
             if (!nodes.length) return undefined;
             if (nodes[0].id.indexOf('-bounding-box') != -1 || isScrollViewContentView) {
                 return BMView.viewForNode(nodes[0] as HTMLElement);
@@ -1434,11 +1434,22 @@ export class BMScrollViewWidget extends BMViewWidget {
      * If this widget already had a view for it, it is released and recreated.
      */
     get rebuiltCoreUIView() {
+        const boundingBox = BMBoundingBoxOfComposerWidget(this);
         if (this._coreUIView) {
             this._coreUIView.release();
             this._coreUIView = undefined;
+
+            // After releasing the view, the content view gets removed from the document
+            // but it needs to be reattached because it is the jqElement
+            boundingBox.appendChild(this.jqElement[0]);
         }
         return this.coreUIView;
+    }
+
+    async afterRender() {
+        super.afterRender();
+
+        this.jqElement[0].classList.add('BMScrollContentView');
     }
 
 }

--- a/src/BMView.runtime.ts
+++ b/src/BMView.runtime.ts
@@ -623,8 +623,8 @@ export class BMScrollViewWidget extends BMViewWidget {
     }
 
     appendTo(container: $, mashup: TWMashup): void {
-        super.appendTo(container, mashup);
         this.subviewMap[(this as any).properties.Id + '-content-view'] = this.coreUIView.contentView;
+        super.appendTo(container, mashup);
 		if (this.getProperty('ScrollbarStyle')) {
             let scrollbarCSS;
 			let scrollbarStyle = TW.getStyleFromStyleDefinition(this.getProperty('ScrollbarStyle'));

--- a/src/styles/ide.css
+++ b/src/styles/ide.css
@@ -24,8 +24,12 @@
     display: none !important;
 }
 
-.BMViewEditorOpen > .au-target {
+.BMViewEditorOpen > .au-target, .BMLayoutEditorManagedView > .au-target {
     display: none !important;
+}
+
+.BMScrollContentView {
+    contain: none !important;
 }
 
 span[class="widget-icon au-target"] {


### PR DESCRIPTION
Resolves an issue where the layout editor did not appear when invoked from a scroll view.

Resolves an issue where constraints did not properly save when specified on a scroll content view.

Resolves an issue where the scroll content view was not selectable in the layout editor.

Resolves an issue where the constraints for a scroll content view were not properly created at runtime.

Resolves an issue where the thingworx binding dropdown was not properly hidden when opening the layout editor.